### PR TITLE
Enable aggressive static analysis flags - resolve resulting issues

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -6,6 +6,10 @@ project ("mm_manager")
 
 set(CMAKE_EXPORT_COMPILE_COMMANDS ON)
 
+# Set the C standard to C11
+set(CMAKE_C_STANDARD 11)
+set(CMAKE_C_STANDARD_REQUIRED ON)
+
 execute_process(COMMAND git describe --dirty --always --tags
                 OUTPUT_VARIABLE GIT_REV
                 ERROR_QUIET)

--- a/mm_accounting.c
+++ b/mm_accounting.c
@@ -10,6 +10,7 @@
  * Copyright (c) 2022, Howard M. Harte
  */
 
+#include <inttypes.h>
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
@@ -512,8 +513,8 @@ int mm_acct_save_TPERFST(mm_context_t* context, dlog_mt_perf_stats_record_t* per
         timestamp_to_string(perf_stats->timestamp, timestamp_str, sizeof(timestamp_str)),
         timestamp_to_string(perf_stats->timestamp2, timestamp2_str, sizeof(timestamp2_str)));
 
-    for (int i = 0; i < ((sizeof(perf_stats->stats) / sizeof(uint16_t))); i++) {
-        if (perf_stats->stats[i] > 0) printf("[%2d] %27s: %5d\n", i, TPERFST_stats_to_str(i), perf_stats->stats[i]);
+    for (size_t i = 0; i < ((sizeof(perf_stats->stats) / sizeof(uint16_t))); i++) {
+        if (perf_stats->stats[i] > 0) printf("[%2zu] %27s: %5d\n", i, TPERFST_stats_to_str(i), perf_stats->stats[i]);
     }
 
     return 0;
@@ -540,7 +541,7 @@ int mm_acct_save_TSTATUS(mm_context_t* context, dlog_mt_term_status_t* dlog_mt_t
     term_status_word |= (uint64_t)(dlog_mt_term_status->status[3]) << 24;
     term_status_word |= (uint64_t)(dlog_mt_term_status->status[4]) << 32;
 
-    printf("\t\tTerminal serial number %s, Terminal Status Word: 0x%010llx\n",
+    printf("\t\tTerminal serial number %s, Terminal Status Word: 0x%010" PRIx64 "\n",
         serial_number, term_status_word);
 
     /* Retrieve the most recent terminal status, and update only if changed. */
@@ -597,7 +598,7 @@ int mm_acct_save_TSTATUS(mm_context_t* context, dlog_mt_term_status_t* dlog_mt_t
             "CODE_SERVER_ABORTED,"
             "TELCO_ID, REGION_CODE"
             ") VALUES ( "
-            "\"%s\",%s,\"%s\",%llu,"
+            "\"%s\",%s,\"%s\",%" PRIu64 ","
             "%d,%d,%d,%d,%d,%d,%d,%d,"
             "%d,%d,%d,%d,%d,%d,%d,%d,"
             "%d,%d,%d,%d,%d,%d,%d,%d,"

--- a/mm_areacode.c
+++ b/mm_areacode.c
@@ -68,7 +68,7 @@ int main(int argc, char *argv[]) {
 
     fclose(instream);
 
-    for (int i = 0; i < sizeof(dlog_mt_npa_sbr_table_t) - 1; i++) {
+    for (size_t i = 0; i < sizeof(dlog_mt_npa_sbr_table_t) - 1; i++) {
         uint8_t c;
         uint8_t flags0, flags1;
 

--- a/mm_callscrn.c
+++ b/mm_callscrn.c
@@ -80,7 +80,7 @@ int main(int argc, char *argv[]) {
     FILE  *ostream = NULL;
     int    callscrn_index;
     char   phone_number_str[20] = { 0 };
-    int    i;
+    size_t i;
     int    callscrn_max_entries = 0;
     int    phone_num_len = 0;
     size_t size;

--- a/mm_carrier.c
+++ b/mm_carrier.c
@@ -271,7 +271,7 @@ int main(int argc, char *argv[]) {
                 (pcarrier_table->carrier[carrier_index].call_entry == 0)) {
                 continue;
             }
-            snprintf(display_prompt_string, sizeof(display_prompt_string) - 1, "                    ");
+            snprintf(display_prompt_string, sizeof(display_prompt_string), "                    ");
         }
 
         carrier_num = ntohs(pcarrier_table->carrier[carrier_index].carrier_num);

--- a/mm_carrier_mtr1.c
+++ b/mm_carrier_mtr1.c
@@ -270,7 +270,7 @@ int main(int argc, char *argv[]) {
                 (pcarrier_table->carrier[carrier_index].call_entry == 0)) {
                 continue;
             }
-            snprintf(display_prompt_string, sizeof(display_prompt_string) - 1, "                    ");
+            snprintf(display_prompt_string, sizeof(display_prompt_string), "                    ");
         }
 
         carrier_num = ntohs(pcarrier_table->carrier[carrier_index].carrier_num);

--- a/mm_config.c
+++ b/mm_config.c
@@ -28,6 +28,9 @@
 #define SQL_IGNORE      ""
 #endif /* MYSQL */
 
+/* Declare function prototypes */
+int mm_config_add_TERMTYP_entry(void *db, uint8_t terminal_type, const char *control_rom_edition, const char *description);
+
 uint8_t mm_config_get_term_type_from_control_rom_edition(void* db, const char* control_rom_edition) {
     char sql[256] = { 0 };
     char db_control_rom_edition[8];

--- a/mm_manager.h
+++ b/mm_manager.h
@@ -1306,8 +1306,8 @@ extern char *timestamp_to_db_string(uint8_t *timestamp, char *string_buf, size_t
 extern char *received_time_to_db_string(char *string_buf, size_t string_buf_len);
 extern char *seconds_to_ddhhmmss_string(char* string_buf, size_t string_buf_len, uint32_t seconds);
 extern const char* error_inject_type_to_str(uint8_t type);
-extern const uint16_t term_type_to_mtr(uint8_t term_type);
-extern const uint8_t term_type_to_model(uint8_t term_type);
+extern uint16_t term_type_to_mtr(uint8_t term_type);
+extern uint8_t term_type_to_model(uint8_t term_type);
 
 extern const char* feature_term_type_to_str(uint8_t type);
 

--- a/mm_proto.c
+++ b/mm_proto.c
@@ -197,7 +197,7 @@ pkt_status_t receive_mm_packet(mm_context_t *context, mm_packet_t *pkt) {
  * Returns PKT_SUCCESS on success, otherwise PKT_ERROR_ code flags.
  */
 pkt_status_t send_mm_packet(mm_context_t* context, uint8_t* payload, size_t len, uint8_t flags) {
-    mm_packet_t pkt = {{0}};
+    mm_packet_t pkt = {0};
     pkt_status_t status = PKT_SUCCESS;
     int retries;
 

--- a/mm_serial.c
+++ b/mm_serial.c
@@ -77,7 +77,7 @@ ssize_t read_serial(mm_serial_context_t *pserial_context, void *buf, size_t coun
         }
     }
     else {
-        for (int i = 0; i < count; i++) {
+        for (size_t i = 0; i < count; i++) {
             if (feof(pserial_context->bytestream)) {
                 printf("%s: Terminating due to EOF.\n", __FUNCTION__);
                 fflush(stdout);
@@ -102,7 +102,7 @@ ssize_t read_serial(mm_serial_context_t *pserial_context, void *buf, size_t coun
     }
 
     if (pserial_context->logstream != NULL) {
-        for (int i = 0; i < count; i++) {
+        for (size_t i = 0; i < count; i++) {
             fprintf(pserial_context->logstream, "UART: RX: %02X\n", ((uint8_t*)buf)[i]);
         }
     }
@@ -113,7 +113,7 @@ ssize_t write_serial(mm_serial_context_t *pserial_context, const void *buf, size
     ssize_t bytes_written = count;
 
     if (pserial_context->logstream != NULL) {
-        for (int i = 0; i < count; i++) {
+        for (size_t i = 0; i < count; i++) {
             fprintf(pserial_context->logstream, "UART: TX: %02X\n", ((uint8_t*)buf)[i]);
         }
     }

--- a/mm_serial_posix.c
+++ b/mm_serial_posix.c
@@ -16,6 +16,8 @@
 #include <termios.h>
 #include <sys/ioctl.h>
 
+#include "mm_serial.h"
+
 /*
  * Open serial port specified in modem_dev.
  *

--- a/mm_smcard.c
+++ b/mm_smcard.c
@@ -8,6 +8,7 @@
  *
  */
 
+#include <inttypes.h>
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
@@ -85,7 +86,7 @@ int main(int argc, char *argv[]) {
            "+--------------------------+\n");
 
     for (index = 0; index < SC_DES_KEY_MAX; index++) {
-        printf("|  %2d | 0x%016llx |\n",
+        printf("|  %2d | 0x%016" PRIx64 " |\n",
                index,
                psmcard_table->des_key[index]);
     }

--- a/mm_tables.c
+++ b/mm_tables.c
@@ -8,6 +8,7 @@
  * Copyright (c) 2022, Howard M. Harte
  */
 
+#include <inttypes.h>
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
@@ -29,7 +30,7 @@ size_t mm_table_load(mm_context_t *context, uint8_t table_id, uint64_t version_t
     char sql[512] = { 0 };
     size_t blob_len;
 
-    snprintf(sql, sizeof(sql), "SELECT TABLE_DATA from TERMDAT where (TABLE_ID = %d and VERSION_TIMESTAMP = %llu);",
+    snprintf(sql, sizeof(sql), "SELECT TABLE_DATA from TERMDAT where (TABLE_ID = %d and VERSION_TIMESTAMP = %" PRIu64 ");",
         table_id, version_timestamp);
 
     blob_len = mm_sql_read_blob(context->database, sql, buffer, buflen);
@@ -42,7 +43,7 @@ int mm_table_save(mm_context_t* context, uint8_t table_id, uint64_t version_time
     int rc;
 
     snprintf(sql, sizeof(sql), "REPLACE INTO TERMDAT (TABLE_ID, VERSION_TIMESTAMP, DATA_LENGTH, TABLE_DATA)"
-        "VALUES ( %d, %llu, %zd, ?);",
+        "VALUES ( %d, %" PRIu64 ", %zd, ?);",
         table_id,
         version_timestamp,
         buflen);
@@ -52,7 +53,7 @@ int mm_table_save(mm_context_t* context, uint8_t table_id, uint64_t version_time
     rc = mm_sql_write_blob(context->database, sql, buffer, buflen);
 
     if (rc != 0) {
-        fprintf(stderr, "%s: Error writing table %d, version %llu\n", __FUNCTION__, table_id, version_timestamp);
+        fprintf(stderr, "%s: Error writing table %d, version %" PRIu64 "\n", __FUNCTION__, table_id, version_timestamp);
     }
 
     return rc;

--- a/mm_util.c
+++ b/mm_util.c
@@ -743,7 +743,7 @@ const uint16_t term_type_mtr[TERM_TYPE_MAX + 1] = {
     MTR_2_X     /* 60 */
 };
 
-const uint16_t term_type_to_mtr(uint8_t term_type) {
+uint16_t term_type_to_mtr(uint8_t term_type) {
     if (term_type > 60) return MTR_UNKNOWN;
     return term_type_mtr[term_type];
 }
@@ -812,7 +812,7 @@ const uint8_t term_type_model[TERM_TYPE_MAX + 1] = {
     TERM_MULTIPAY       /* 60 */
 };
 
-const uint8_t term_type_to_model(uint8_t term_type) {
+uint8_t term_type_to_model(uint8_t term_type) {
     if (term_type > 60) return MTR_UNKNOWN;
     return term_type_model[term_type];
 }


### PR DESCRIPTION
Enable -Wall -Wextra and -Werror (as well as a few more useful lints) and then fix everything to get it compiling.

* The snprintf statements in mm_carrier.c and mm_carrier_mtrl.c seem to leave a space for the null terminator, but snprintf guarantees a null terminator, so you will get truncation!
* A number of places had for loops with `int i` but were compared against the output of `sizeof` - switched them to `size_t i`
* There were a number of places which used `%llx`, `%lld`, and `%llu` to print out uint64_t or int64_t types - switch these to their standard `PRIx64`, `PRId64`, and `PRIu64` counterparts
* Add in a few missing function prototypes
* Remove const from some functions which claimed their return type was const, which didn't make sense since the functions returned basic types by copy