### PR TITLE
Update term_type_mtr

### DIFF
--- a/src/mm_manager.c
+++ b/src/mm_manager.c
@@ -231,7 +231,7 @@ uint8_t table_list_mtr17_intl[] = {
     DLOG_MT_COIN_VAL_TABLE,     /* Required */
     DLOG_MT_REP_DIAL_LIST,
     DLOG_MT_LIMSERV_DATA,
-    DLOG_MT_CALLSCRN_EXP,
+    DLOG_MT_CALLSCRN_UNIVERSAL,
     DLOG_MT_NUM_PLAN_TABLE,     /* Required */
     DLOG_MT_RATE_TABLE,         /* Required */
     DLOG_MT_LCD_TABLE_1,        /* MTR 1.7 Length: 819 */

--- a/src/mm_util.c
+++ b/src/mm_util.c
@@ -733,66 +733,66 @@ const char* error_inject_type_to_str(uint8_t type) {
 
 const uint16_t term_type_mtr[TERM_TYPE_MAX + 1] = {
     MTR_UNKNOWN,
-    MTR_2_X,    /* 1 */
+    MTR_2_X,     /* 1 */
     MTR_2_X,
     MTR_2_X,
     MTR_UNKNOWN,
-    MTR_2_X,    /* 5 */
+    MTR_2_X,     /* 5 */
     MTR_1_9,
     MTR_2_X,
     MTR_1_6,
     MTR_1_6,
-    MTR_1_13,   /* 10 */
+    MTR_1_13,    /* 10 */
+    MTR_1_7,
+    MTR_1_7_INTL, /* 12: 06CNB02 */
     MTR_1_7,
     MTR_1_7,
-    MTR_1_7,
-    MTR_1_7,
-    MTR_1_7,    /* 15 */
+    MTR_1_7,     /* 15 */
     MTR_1_7,
     MTR_2_X,
     MTR_1_20,
     MTR_1_7,
-    MTR_1_20,   /* 20 */
+    MTR_1_20,    /* 20 */
     MTR_1_7,
-    MTR_2_X,
+    MTR_2_X,     /* 22: MTR 2.0 - Multipay, ADSI */
     MTR_1_7,
     MTR_1_7,
-    MTR_1_7,    /* 25 */
+    MTR_1_7,     /* 25 */
     MTR_1_7,
-    MTR_1_9,    /* 27: MTR 1.9 Card-only */
+    MTR_1_9,     /* 27: MTR 1.9 - Card */
     MTR_1_9,
     MTR_1_9,
-    MTR_1_9,    /* 30 */
+    MTR_1_9,     /* 30 */
     MTR_1_9,
     MTR_1_7_INTL,
     MTR_1_9,
     MTR_2_X,
-    MTR_2_X,    /* 35 */
-    MTR_1_13,   /* NCA1X03, MTR 2.0 appears to use the same tables as 1.13. */
+    MTR_2_X,     /* 35 */
+    MTR_1_13,    /* 36: NCA1X03, MTR 2.0 appears to use the same tables as 1.13. */
     MTR_1_13,
     MTR_2_X,
-    MTR_2_X,
-    MTR_2_X,    /* 40 */
-    MTR_UNKNOWN,
+    MTR_2_X,     /* 39: MTR 2.0 - Card, ADSI */
+    MTR_2_X,     /* 40: MTR 2.0 - Multipay, ADSI */
+    MTR_UNKNOWN, /* 41: "MTR 2.4" - Proton */
     MTR_1_9,
-    MTR_UNKNOWN,
+    MTR_1_11,    /* MTR 1.11 - Card */
     MTR_1_10,
-    MTR_1_11,   /* 45 */
+    MTR_1_11,    /* 45 */
     MTR_1_9,
-    MTR_UNKNOWN,
-    MTR_UNKNOWN,
-    MTR_UNKNOWN,
-    MTR_UNKNOWN,/* 50 */
+    MTR_1_11,
+    MTR_1_11,
+    MTR_1_11,
+    MTR_2_X,     /* 50 */
     MTR_2_X,
-    MTR_UNKNOWN,
-    MTR_UNKNOWN,
-    MTR_UNKNOWN,
-    MTR_UNKNOWN,/* 55 */
+    MTR_2_X,
+    MTR_2_X,
+    MTR_2_X,
+    MTR_1_7,     /* 55 */
     MTR_2_X,
     MTR_2_X,
     MTR_1_20,
     MTR_2_X,
-    MTR_2_X     /* 60 */
+    MTR_2_X      /* 60 */
 };
 
 uint16_t term_type_to_mtr(uint8_t term_type) {
@@ -844,19 +844,19 @@ const uint8_t term_type_model[TERM_TYPE_MAX + 1] = {
     TERM_MULTIPAY,      /* 40 */
     TERM_MULTIPAY,
     TERM_COIN_BASIC,
-    TERM_MULTIPAY,
+    TERM_CARD,
     TERM_MULTIPAY,
     TERM_DESK,          /* 45 */
     TERM_MULTIPAY,
+    TERM_CARD,
     TERM_MULTIPAY,
+    TERM_DESK,
+    TERM_CARD,          /* 50 */
     TERM_MULTIPAY,
+    TERM_CARD,
     TERM_MULTIPAY,
-    TERM_MULTIPAY,      /* 50 */
-    TERM_MULTIPAY,
-    TERM_MULTIPAY,
-    TERM_MULTIPAY,
-    TERM_MULTIPAY,
-    TERM_MULTIPAY,      /* 55 */
+    TERM_CARD,
+    TERM_DESK,          /* 55 */
     TERM_COIN_BASIC,
     TERM_MULTIPAY,
     TERM_CARD,


### PR DESCRIPTION
Better late than never :)

Fixes term_type=12 to MTR_1_7_INTL and changes table_list_mtr17_intl to contain DLOG_MT_CALLSCRN_UNIVERSAL instead of DLOG_MT_CALLSCRN_EXP. 

This now works for provisioning firmware version 06CNB02.

I also updated some other term_types from MTR_UNKNOWN to the types that I was able to map out, the detailed table is here: https://docs.google.com/spreadsheets/d/1QwyEDyWJDddWE50xEzhHSkKrcSYOGkgI_AEq2LASs1o/edit?usp=sharing
